### PR TITLE
typo in functionname "is_alpha_or_dot"

### DIFF
--- a/includes/js/jquery.validations.js
+++ b/includes/js/jquery.validations.js
@@ -81,7 +81,7 @@ function is_alpha(field,error) {
 	}
 }
 
-function is_alpha_or_dor(field,error) {
+function is_alpha_or_dot(field,error) {
 	var checkme = field.value;
 	if (!(checkme.match(/^[a-zA-Z0-9.]+$/))) {
 		add_error_to_field(field, error);


### PR DESCRIPTION
pretty sure you meant is_alpha_or_doT instead of doR

function was added in last commit, but no other change referencing the function was found, so save to be changed.