### PR TITLE
Prevent session lock during download

### DIFF
--- a/process.php
+++ b/process.php
@@ -124,6 +124,7 @@ class process {
 						$new_record_action = $new_log_action->log_action_save($log_action_args);
 						$this->real_file = UPLOADED_FILES_FOLDER.$this->real_file_url;
 						if (file_exists($this->real_file)) {
+							session_write_close();
 							while (ob_get_level()) ob_end_clean();
 							header('Content-Type: application/octet-stream');
 							header('Content-Disposition: attachment; filename='.basename($this->real_file));


### PR DESCRIPTION
While downloading a file, the user is not able to use the site due to PHP session lock, see e.g. http://konrness.com/php5/how-to-prevent-blocking-php-requests/. Closing the session for writing before sending the file resolves this problem. Any objections?