### PR TITLE
Minor typo on options page

### DIFF
--- a/lang/ca_ES.po
+++ b/lang/ca_ES.po
@@ -2904,7 +2904,7 @@ msgstr "Quan un usuari puja arxius"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 "Quan s'estableixi una contrassenya per un compte, requerir com a mínim:"
 

--- a/lang/cs.po
+++ b/lang/cs.po
@@ -2844,7 +2844,7 @@ msgstr "Když systémový uživatel nahraje soubor"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 
 #. Text in function

--- a/lang/da.po
+++ b/lang/da.po
@@ -2873,7 +2873,7 @@ msgstr "Når en systembruger uploader filer"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Når en adgangskode opsættes for en bruger kræves mindst:"
 
 #. Text in function

--- a/lang/de.po
+++ b/lang/de.po
@@ -2935,7 +2935,7 @@ msgstr "Sobald ein Systembenutzer Dateien hochlädt"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Beim Account-Passwort zumindest erforderlich:"
 
 #. Text in function

--- a/lang/en.po
+++ b/lang/en.po
@@ -2743,7 +2743,7 @@ msgstr ""
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 
 #. Text in function

--- a/lang/en.pot
+++ b/lang/en.pot
@@ -2743,7 +2743,7 @@ msgstr ""
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 
 #. Text in function

--- a/lang/es.po
+++ b/lang/es.po
@@ -2903,7 +2903,7 @@ msgstr "Cuando un usuario sube archivos"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Al establecer una contraseña para una cuenta, requerir al menos:"
 
 #. Text in function

--- a/lang/fi.po
+++ b/lang/fi.po
@@ -2860,7 +2860,7 @@ msgstr "Kun järjestelmäkäyttäjä lähettää tiedostoja"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 
 #. Text in function

--- a/lang/fr.po
+++ b/lang/fr.po
@@ -2927,7 +2927,7 @@ msgstr "Quand un utilisateur système transfert des fichiers"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Les mots de passe nécessitent au minimum:"
 
 #. Text in function

--- a/lang/it_IT.po
+++ b/lang/it_IT.po
@@ -2930,7 +2930,7 @@ msgstr "Quando un utente di sistema carica file"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Quando crei una password per un account, è richiesto almeno:"
 
 #. Text in function

--- a/lang/nl.po
+++ b/lang/nl.po
@@ -2878,7 +2878,7 @@ msgstr "Als een beheerder bestanden uploadt"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 "Wanneer een wachtwoord voor een account word aangemaakt, dan moet deze "
 "minimaal het volgende bevatten:"

--- a/lang/pt_BR.po
+++ b/lang/pt_BR.po
@@ -2881,7 +2881,7 @@ msgstr "Quando um adminstrador envia arquivos"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Ao configurar a senha para uma cont, forneça pelo menos:"
 
 #. Text in function

--- a/lang/pt_PT.po
+++ b/lang/pt_PT.po
@@ -2913,7 +2913,7 @@ msgstr "Quando um Utilizador de Sistema carrega um ficheiro"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Ao definir a Password para uma Conta solicitar, pelo menos:"
 
 #. Text in function

--- a/lang/sl.po
+++ b/lang/sl.po
@@ -2787,7 +2787,7 @@ msgstr "Ko sistemski uporabnik naloži datoteko"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "Ko se nastavlja geslo za račun, zahtevamo vsaj:"
 
 #. Text in function

--- a/lang/sv.po
+++ b/lang/sv.po
@@ -2848,7 +2848,7 @@ msgstr "När en systemanvändare laddar upp filer"
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr ""
 
 #. Text in function

--- a/lang/uk.po
+++ b/lang/uk.po
@@ -2893,7 +2893,7 @@ msgstr "Коли системний користувач завантажує ф
 
 #. Text in echo
 #: options.php:452
-msgid "When setting up a password for an account, requiere at least:"
+msgid "When setting up a password for an account, require at least:"
 msgstr "При встановленні паролю для облікового запису вимагати щонайменше:"
 
 #. Text in function

--- a/options.php
+++ b/options.php
@@ -449,7 +449,7 @@ $allowed_file_types = implode(',',$allowed_file_types);
 
 									<li>
 										<h3><?php _e('Passwords','cftp_admin'); ?></h3>
-										<p><?php _e('When setting up a password for an account, requiere at least:','cftp_admin'); ?><br />
+										<p><?php _e('When setting up a password for an account, require at least:','cftp_admin'); ?><br />
 									</li>
 									<li>
 										<label for="pass_require_upper"><?php echo $validation_req_upper; ?></label>


### PR DESCRIPTION
Hi,

I was just looking through the system and spotted this typo - "requiere" as opposed to "require". It appears on the system options -> security page.

Cheers,
Rob
