### PR TITLE
FIX: PHP7 compatibility

### DIFF
--- a/includes/phpass/PasswordHash.php
+++ b/includes/phpass/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
In PHP7 class constructor with class name are deprecated.
