### PR TITLE
Fix new client by user custom email template

### DIFF
--- a/includes/classes/send-email.php
+++ b/includes/classes/send-email.php
@@ -105,7 +105,7 @@ class PSend_Email
 		switch ($type) {
 			case 'new_client':
 					$filename	= 'new-client.html';
-					$body_check	= (!defined('EMAILS_HEADER_FOOTER_CUSTOM') || EMAILS_HEADER_FOOTER_CUSTOM == '0') ? '0' : EMAILS_CLIENT_BY_USER_USE_CUSTOM;
+					$body_check	= (!defined('EMAILS_CLIENT_BY_USER_USE_CUSTOM') || EMAILS_CLIENT_BY_USER_USE_CUSTOM == '0') ? '0' : EMAILS_CLIENT_BY_USER_USE_CUSTOM;
 					$body_text	= EMAILS_CLIENT_BY_USER_TEXT;
 				break;
 			case 'new_client_self':


### PR DESCRIPTION
Fix for custom email template for new clients added by user through the includes/classes/send-email.php line 108 as per issue https://github.com/ignacionelson/ProjectSend/issues/18.