### PR TITLE
Remove unnecessary install-time dependency on MySQL >= 5.6.5.

### DIFF
--- a/install/database.php
+++ b/install/database.php
@@ -23,7 +23,7 @@ if (defined('TRY_INSTALL')) {
 								  `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
 								  `uploader` varchar('.MAX_USER_CHARS.') NOT NULL,
 								  `expires` INT(1) NOT NULL default \'0\',
-								  `expiry_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+								  `expiry_date` TIMESTAMP NOT NULL DEFAULT \'0000-00-00 00:00:00\',
 								  `public_allow` INT(1) NOT NULL default \'0\',
 								  `public_token` varchar(32) NULL,
 								  PRIMARY KEY (`id`)


### PR DESCRIPTION
This fixes issue #203 while not re-introducing #136 because a dummy default value is used.

It is not strictly necessary to have a meaningful value stored in `expiry_date` on insertion. This will only be relevant when `expires` is set to `1` in which case the dummy `expiry_date` default value will be overwritten anyway. No need to use `CURRENT_TIMESTAMP()` again, which would require a more recent MySQL version.