### PR TITLE
Fixed port number problem when behind reverse proxy

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -688,11 +688,12 @@ function get_current_url()
 		}
 	}
 	$pageURL .= "://";
-	if ($_SERVER["SERVER_PORT"] != "80") {
-		$pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"].$_SERVER["REQUEST_URI"];
-	} else {
-		$pageURL .= $_SERVER["SERVER_NAME"].$_SERVER["REQUEST_URI"];
-	}
+	/*
+	** Using $_SERVER["HTTP_HOST"] now.
+	** Fixing problems wth the old solution: $_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"] when using a reverse proxy.
+	** HTTP_HOST already includes port number (if non-standard), no specific handling of port number necessary.
+	*/
+	$pageURL .= $_SERVER["HTTP_HOST"].$_SERVER["REQUEST_URI"];
 
 	/**
 	 * Check if we are accesing the install folder or the index.php file directly


### PR DESCRIPTION
Hi there,
I tried installing ProjectSend behind a reverse proxy. The request URL was standard on port 80, but the server port (on the "upstream" host in nginx talk) was 8001. ProjectSend - in good intention - automatically added a ":8001" to the URL, which however doesn't belong there. 8001 is just the port number BEHIND the reverse proxy, but the site is not reachable under port 8001 because nginx (set up as a reverse proxy) maps incoming requests on port 80 to port 8001 on the upstream host.
Please see my changes to fix that. Made the code even simpler! ;-)
Can now install (and run) with correct port number even behind reverse proxies. :-)