### PR TITLE
Securely deleting files

### DIFF
--- a/includes/core.update.php
+++ b/includes/core.update.php
@@ -1044,15 +1044,30 @@ if (in_session_or_cookies($allowed_update)) {
 				$updates_made++;
 			}
 		}
-		
+
 		/**
 		 * r757 updates
 		 * Add new options that clients can set expiration date when Uploded New files 
 		 */
 		 
-			if ($last_update < 757) {
+		if ($last_update < 757) {
 			$new_database_values = array(
 											'clients_can_set_expiration_date'	=> '0'
+    									);
+			
+			foreach($new_database_values as $row => $value) {
+				if ( add_option_if_not_exists($row, $value) ) {
+					$updates_made++;
+				}
+			}
+        }
+        
+        /** 
+         * Add an option to securely delete files using shred
+         */
+        if ($last_update < 758) {
+            $new_database_values = array(
+											'secure_delete_files'	=> '0'
 										);
 			
 			foreach($new_database_values as $row => $value) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -790,7 +790,13 @@ function delete_file_from_disk($filename)
 {
 	if ( file_exists( $filename ) ) {
 		chmod($filename, 0777);
-		unlink($filename);
+        
+        if (SECURE_DELETE_FILES == '1') {
+            shell_exec("shred -u " . escapeshellarg($filename));
+        }
+        else {
+           	unlink($filename);
+        }
 	}
 }
 
@@ -810,7 +816,13 @@ function delete_recursive($dir)
 					}
 					else {
 						chmod($dir.$file, 0777);
-						unlink($dir.$file);
+                        
+                        if (SECURE_DELETE_FILES == '1') {
+                            shell_exec("shred -u " . escapeshellarg($dir.$file));
+						}
+                        else {
+                            unlink($dir.$file);
+                        }
 					}
 				}
 		   }

--- a/includes/shred-check.php
+++ b/includes/shred-check.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File to check if the 'shred' command is installed.
+ * This command is installed by default on ubuntu servers.
+ * This file is called in options.php, when the user tries to enable
+ * the option to securely delete files.
+ *
+ * @package ProjectSend
+ */
+
+if(empty(shell_exec("shred --version"))){
+  echo '{"installed":false}';
+} else {
+  echo '{"installed":true}';
+}
+
+?>

--- a/includes/site.options.php
+++ b/includes/site.options.php
@@ -226,6 +226,14 @@ if(!empty($options_values)) {
 	if (isset($options_values['clients_auto_approve'])) {
 		define('CLIENTS_CAN_SET_EXPIRATION_DATE',$options_values['clients_can_set_expiration_date']);
 	}
+    
+    /**
+     * For a newer version
+     * Securely delete files with shred
+     */
+    if (isset($options_values['secure_delete_files'])) {
+		define('SECURE_DELETE_FILES',$options_values['secure_delete_files']);
+	}
 
 	/**
 	 * Set the default timezone based on the value of the Timezone select box

--- a/includes/vars.php
+++ b/includes/vars.php
@@ -22,6 +22,7 @@ if ( !defined( 'USER_ROLE_LVL_0' ) ) { define('USER_ROLE_LVL_0', $user_role_0_na
 /**
  * Validation class strings
  */
+$validation_seure_delete	= __('Securely delete files','cftp_admin');
 $validation_recaptcha		= __('reCAPTCHA verification failed','cftp_admin');
 $validation_no_name			= __('Name was not completed','cftp_admin');
 $validation_no_client		= __('No client was selected','cftp_admin');

--- a/install/database.php
+++ b/install/database.php
@@ -23,7 +23,7 @@ if (defined('TRY_INSTALL')) {
 								  `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
 								  `uploader` varchar('.MAX_USER_CHARS.') NOT NULL,
 								  `expires` INT(1) NOT NULL default \'0\',
-								  `expiry_date` TIMESTAMP NOT NULL DEFAULT \'0000-00-00 00:00:00\',
+								  `expiry_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
 								  `public_allow` INT(1) NOT NULL default \'0\',
 								  `public_token` varchar(32) NULL,
 								  PRIMARY KEY (`id`)
@@ -278,7 +278,8 @@ if (defined('TRY_INSTALL')) {
 								('google_signin_enabled', '0'),
 								('recaptcha_enabled', '0'),
 								('recaptcha_site_key', ''),
-								('recaptcha_secret_key', '')
+								('recaptcha_secret_key', ''),
+                                ('secure_delete_files', '0')
 								",
 					'params' => array(
 										':base_uri'	=> $base_uri,

--- a/install/database.php
+++ b/install/database.php
@@ -23,7 +23,7 @@ if (defined('TRY_INSTALL')) {
 								  `timestamp` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
 								  `uploader` varchar('.MAX_USER_CHARS.') NOT NULL,
 								  `expires` INT(1) NOT NULL default \'0\',
-								  `expiry_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+								  `expiry_date` TIMESTAMP NOT NULL DEFAULT \'0000-00-00 00:00:00\',
 								  `public_allow` INT(1) NOT NULL default \'0\',
 								  `public_token` varchar(32) NULL,
 								  PRIMARY KEY (`id`)
@@ -279,9 +279,9 @@ if (defined('TRY_INSTALL')) {
 								('recaptcha_enabled', '0'),
 								('recaptcha_site_key', ''),
 								('recaptcha_secret_key', ''),
-                                ('secure_delete_files', '0')
+                                				('secure_delete_files', '0')
 								",
-					'params' => array(
+								'params' => array(
 										':base_uri'	=> $base_uri,
 										':title'	=> $this_install_title,
 										':email'	=> $got_admin_email,

--- a/options.php
+++ b/options.php
@@ -602,7 +602,7 @@ $allowed_file_types = implode(',',$allowed_file_types);
 										<div class="options_divide"></div>
 			
 										<h3><?php _e('File deletion','cftp_admin'); ?></h3>
-										<p><?php _e('Securely delete files usig "shred -v", only enable when installed (installed by default on ubuntu)','cftp_admin'); ?></p>
+										<p><?php _e('Securely delete files using the Unix command "shred -u". Make sure to check that this command is available on your server before enabling this options.','cftp_admin'); ?></p>
 			
 										<div class="form-group">
 											<div class="col-sm-8 col-sm-offset-4">

--- a/options.php
+++ b/options.php
@@ -42,6 +42,7 @@ if ($_POST) {
 
 	/** Checkboxes */
 	$checkboxes	= array(
+                        'secure_delete_files',
 						'recaptcha_enabled',
 						'clients_can_delete_own_files',
 						'use_browser_lang',
@@ -599,6 +600,17 @@ $allowed_file_types = implode(',',$allowed_file_types);
 										</div>
 			
 										<div class="options_divide"></div>
+			
+										<h3><?php _e('File deletion','cftp_admin'); ?></h3>
+										<p><?php _e('Securely delete files usig "shred -v", only enable when installed (installed by default on ubuntu)','cftp_admin'); ?></p>
+			
+										<div class="form-group">
+											<div class="col-sm-8 col-sm-offset-4">
+												<label for="secure_delete_files">
+													<input type="checkbox" value="1" name="secure_delete_files" id="secure_delete_files" class="checkbox_options" <?php echo (SECURE_DELETE_FILES == 1) ? 'checked="checked"' : ''; ?> /> <?php  _e('Securely delete files'); ?>
+												</label>
+											</div>
+										</div>
 		
 										<div class="options_divide"></div>
 		

--- a/options.php
+++ b/options.php
@@ -42,7 +42,7 @@ if ($_POST) {
 
 	/** Checkboxes */
 	$checkboxes	= array(
-                        'secure_delete_files',
+						'secure_delete_files',
 						'recaptcha_enabled',
 						'clients_can_delete_own_files',
 						'use_browser_lang',
@@ -178,6 +178,27 @@ $allowed_file_types = implode(',',$allowed_file_types);
 
 					// show the errors or continue if everything is ok
 					if (show_form_errors() == false) { alert('<?php _e('Please complete all the fields.','cftp_admin'); ?>'); return false; }
+				});
+
+				$('#secure_delete_files').change(function() {
+					// We only check when enabling shred
+					var box_element = $(this);
+					if (box_element.is(':checked'))
+						$.getJSON({
+							url: 'includes/shred-check.php',
+							success: function(data) {
+								if(!data.installed) {
+									alert('<?php _e('shred not found','cftp_admin'); ?>');
+									box_element.prop('checked', false);
+									box_element.parent().addClass("alert alert-danger");
+									box_element.parent().text('<?php _e('shred not found','cftp_admin'); ?>');
+								}
+							},
+							error: function(data) {
+								alert('<?php _e('Server error executing shred-check script','cftp_admin'); ?>');
+								box_element.prop('checked', false);
+							}
+						});
 				});
 			});
 		</script>


### PR DESCRIPTION
Added an option to securely delete files. This is achieved by using the
shred command (installed by default on ubuntu servers).

Tested by manually making a hard link of a file, when the option is
enabled the linked file is destroyed as well. When secure deletion is
disabled the linked file still has the original contents.
