### PR TITLE
Removing tab before PHP tag in categories.php

### DIFF
--- a/categories.php
+++ b/categories.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 /**
  * Allows to hide, show or delete the files assigend to the
  * selected client.


### PR DESCRIPTION
Because of this extra white space, PHP outputs the header before the session is created. See bug https://github.com/ignacionelson/ProjectSend/issues/253