### PR TITLE
Get the real filesize

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -764,10 +764,10 @@ function get_real_size($file)
 		}
     }
 	elseif (PHP_OS == 'Darwin') {
-		$ff = trim(shell_exec("stat -f %z " . escapeshellarg($file)));
+		$ff = trim(shell_exec("stat -L -f %z " . escapeshellarg($file)));
     }
 	elseif ((PHP_OS == 'Linux') || (PHP_OS == 'FreeBSD') || (PHP_OS == 'Unix') || (PHP_OS == 'SunOS')) {
-		$ff = trim(shell_exec("stat -c%s " . escapeshellarg($file)));
+		$ff = trim(shell_exec("stat -L -c%s " . escapeshellarg($file)));
     }
 	else {
 		$ff = filesize($file);


### PR DESCRIPTION
In case the file is a symlink, get the size from the real file not the symlink itself