### PR TITLE
Fix filename for public link download

### DIFF
--- a/download.php
+++ b/download.php
@@ -49,6 +49,7 @@ include('header-unlogged.php');
 			}
 
 			$real_file_url	= (!empty( $got_url['original_url'] ) ) ? $got_url['original_url'] : $got_url['url'];;
+			$file_on_disk	= $got_url['url'];
 		}
 		else {
 			$can_download = false;
@@ -86,8 +87,9 @@ include('header-unlogged.php');
 
 				// DOWNLOAD
 				$real_file = UPLOADED_FILES_FOLDER.basename($real_file_url);
-				if (file_exists($real_file)) {
-					session_write_close(); 
+				$random_file = UPLOADED_FILES_FOLDER.basename($file_on_disk);
+				if (file_exists($random_file)) {
+					session_write_close();
 					while (ob_get_level()) ob_end_clean();
 					header('Content-Type: application/octet-stream');
 					header('Content-Disposition: attachment; filename='.basename($real_file));
@@ -95,12 +97,12 @@ include('header-unlogged.php');
 					header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
 					header('Pragma: public');
 					header('Cache-Control: private',false);
-					header('Content-Length: ' . get_real_size($real_file));
+					header('Content-Length: ' . get_real_size($random_file));
 					header('Connection: close');
 					//readfile($real_file);
 					
 					$context = stream_context_create();
-					$file = fopen($real_file, 'rb', FALSE, $context);
+					$file = fopen($random_file, 'rb', FALSE, $context);
 					while ( !feof( $file ) ) {
 						//usleep(1000000); //Reduce download speed
 						echo stream_get_contents($file, 2014);


### PR DESCRIPTION
Uploaded file gets renamed using timestamp and SHA1 hash
according to upload_move() function
in "includes/classes/file-upload.php".

If we are to use public link to download a file we have
to use "tbl_files.url" table field name
(not the "tbl_files.original_url")
to open and read file data from disk.

Issue #409: https://github.com/ignacionelson/ProjectSend/issues/409
Modification created originally by https://github.com/remez