### PR TITLE
Update statistics.php

### DIFF
--- a/includes/widgets/statistics.php
+++ b/includes/widgets/statistics.php
@@ -100,7 +100,7 @@
 		$statement = $dbh->prepare("SELECT timestamp, COUNT(*) as total
 										FROM " . TABLE_DOWNLOADS . " 
 										WHERE timestamp >= DATE_SUB( CURDATE(),INTERVAL :max_days DAY)
-										GROUP BY DATE(timestamp)
+										GROUP BY timestamp
 									");
 		$statement->execute( $params );
 		if ( $statement->rowCount() > 0 ) {
@@ -118,7 +118,7 @@
 										FROM " . TABLE_LOG . " 
 										WHERE timestamp >= DATE_SUB( CURDATE(),INTERVAL :max_days DAY)
 										AND action IN (".$actions.")
-										GROUP BY DATE(timestamp), action
+										GROUP BY timestamp, action
 									");
 		$statement->execute( $params );
 		if ( $statement->rowCount() > 0 ) {


### PR DESCRIPTION
GROUP BY DATE() is incompatible with the default strict mode or the option ONLY_FULL_GROUP_BY
Fixes #449