### PR TITLE
Notify account opt

### DIFF
--- a/clients-add.php
+++ b/clients-add.php
@@ -128,11 +128,11 @@ if ($_POST) {
 					 */
 					switch ($new_response['email']) {
 						case 2:
-							$msg = __('An e-mail notification was not sent to your client.','cftp_admin');
+							$msg = __('A welcome message was not sent to your client.','cftp_admin');
 							echo system_message('ok',$msg);
 						break;
 						case 1:
-							$msg = __('An e-mail notification with login information was sent to your client.','cftp_admin');
+							$msg = __('A welcome message with login information was sent to your client.','cftp_admin');
 							echo system_message('ok',$msg);
 						break;
 						case 0:

--- a/clients-add.php
+++ b/clients-add.php
@@ -20,11 +20,12 @@ $page_title = __('Add client','cftp_admin');
 include('header.php');
 
 /**
- * Set checkboxes as 1 to defaul them to checked when first entering
+ * Set checkboxes as 1 to default them to checked when first entering
  * the form
  */
-$add_client_data_notity = 1;
+$add_client_data_notify_upload = 1;
 $add_client_data_active = 1;
+$add_client_data_notify_account = 1;
 
 if ($_POST) {
 	$new_client = new ClientActions();
@@ -41,7 +42,8 @@ if ($_POST) {
 	$add_client_data_phone = (isset($_POST["add_client_form_phone"])) ? encode_html($_POST["add_client_form_phone"]) : '';
 	$add_client_data_intcont = (isset($_POST["add_client_form_intcont"])) ? encode_html($_POST["add_client_form_intcont"]) : '';
 	$add_client_data_maxfilesize = (isset($_POST["add_client_form_maxfilesize"])) ? encode_html($_POST["add_client_form_maxfilesize"]) : '';
-	$add_client_data_notity = (isset($_POST["add_client_form_notify"])) ? 1 : 0;
+	$add_client_data_notify_upload = (isset($_POST["add_client_form_notify_upload"])) ? 1 : 0;
+	$add_client_data_notify_account = (isset($_POST["add_client_form_notify_account"])) ? 1 : 0;
 	$add_client_data_active = (isset($_POST["add_client_form_active"])) ? 1 : 0;
 
 	/** Arguments used on validation and client creation. */
@@ -55,7 +57,8 @@ if ($_POST) {
 							'address'		=> $add_client_data_addr,
 							'phone'			=> $add_client_data_phone,
 							'contact'		=> $add_client_data_intcont,
-							'notify'		=> $add_client_data_notity,
+							'notify_upload' 	=> $add_client_data_notify_upload,
+							'notify_account' 	=> $add_client_data_notify_account,
 							'active'		=> $add_client_data_active,
 							'max_file_size'	=> $add_client_data_maxfilesize,
 							'type'			=> 'new_client',
@@ -124,6 +127,10 @@ if ($_POST) {
 					 * Show the ok or error message for the email notification.
 					 */
 					switch ($new_response['email']) {
+						case 2:
+							$msg = __('An e-mail notification was not sent to your client.','cftp_admin');
+							echo system_message('ok',$msg);
+						break;
 						case 1:
 							$msg = __('An e-mail notification with login information was sent to your client.','cftp_admin');
 							echo system_message('ok',$msg);

--- a/clients-edit.php
+++ b/clients-edit.php
@@ -47,7 +47,7 @@ if ($page_status === 1) {
 		$add_client_data_phone			= $data['phone'];
 		$add_client_data_intcont		= $data['contact'];
 		$add_client_data_maxfilesize	= $data['max_file_size'];
-		if ($data['notify'] == 1) { $add_client_data_notity = 1; } else { $add_client_data_notity = 0; }
+		if ($data['notify'] == 1) { $add_client_data_notify_upload = 1; } else { $add_client_data_notify_upload = 0; }
 		if ($data['active'] == 1) { $add_client_data_active = 1; } else { $add_client_data_active = 0; }
 	}
 
@@ -110,7 +110,7 @@ if ($_POST) {
 	$add_client_data_addr			= (isset($_POST["add_client_form_address"])) ? $_POST["add_client_form_address"] : '';
 	$add_client_data_phone			= (isset($_POST["add_client_form_phone"])) ? $_POST["add_client_form_phone"] : '';
 	$add_client_data_intcont		= (isset($_POST["add_client_form_intcont"])) ? $_POST["add_client_form_intcont"] : '';
-	$add_client_data_notity			= (isset($_POST["add_client_form_notify"])) ? 1 : 0;
+	$add_client_data_notify_upload  	= (isset($_POST["add_client_form_notify_upload"])) ? 1 : 0;
 
 	if ( $ignore_size == false ) {
 		$add_client_data_maxfilesize	= (isset($_POST["add_client_form_maxfilesize"])) ? $_POST["add_client_form_maxfilesize"] : '';
@@ -132,7 +132,7 @@ if ($_POST) {
 							'address'		=> $add_client_data_addr,
 							'phone'			=> $add_client_data_phone,
 							'contact'		=> $add_client_data_intcont,
-							'notify'		=> $add_client_data_notity,
+							'notify_upload' 	=> $add_client_data_notify_upload,
 							'active'		=> $add_client_data_active,
 							'max_file_size'	=> $add_client_data_maxfilesize,
 							'type'			=> 'edit_client'

--- a/clients-form.php
+++ b/clients-form.php
@@ -284,11 +284,25 @@ switch ($clients_form_type) {
 
 	<div class="form-group">
 		<div class="col-sm-8 col-sm-offset-4">
-			<label for="add_client_form_notify">
-				<input type="checkbox" name="add_client_form_notify" id="add_client_form_notify" <?php echo (isset($add_client_data_notity) && $add_client_data_notity == 1) ? 'checked="checked"' : ''; ?>> <?php _e('Notify new uploads by e-mail','cftp_admin'); ?>
+			<label for="add_client_form_notify_upload">
+				<input type="checkbox" name="add_client_form_notify_upload" id="add_client_form_notify_upload" <?php echo (isset($add_client_data_notify_upload) && $add_client_data_notify_upload == 1) ? 'checked="checked"' : ''; ?>> <?php _e('Notify new uploads by e-mail','cftp_admin'); ?>
 			</label>
 		</div>
 	</div>
+
+	<?php
+		if ( $clients_form_type == 'new_client' ) {
+	?>
+			<div class="form-group">
+				<div class="col-sm-8 col-sm-offset-4">
+					<label for="add_client_form_notify_account">
+						<input type="checkbox" name="add_client_form_notify_account" id="add_client_form_notify_account" <?php echo (isset($add_client_data_notify_account) && $add_client_data_notify_account == 1) ? 'checked="checked"' : ''; ?>> <?php _e('Notify user of account creation by e-mail','cftp_admin'); ?>
+					</label>
+				</div>
+			</div>
+	<?php
+		}
+	?>
 	
 	<?php
 		if ( $clients_form_type == 'new_client_self' ) {
@@ -312,7 +326,7 @@ switch ($clients_form_type) {
 
 	<?php
 		if ($info_box == true) {
-			$msg = __('This account information will be e-mailed to the address supplied above','cftp_admin');
+			$msg = __('This account information will be e-mailed to the address supplied above by default unless de-selected','cftp_admin');
 			echo system_message('info',$msg);
 		}
 	?>

--- a/clients-form.php
+++ b/clients-form.php
@@ -296,7 +296,7 @@ switch ($clients_form_type) {
 			<div class="form-group">
 				<div class="col-sm-8 col-sm-offset-4">
 					<label for="add_client_form_notify_account">
-						<input type="checkbox" name="add_client_form_notify_account" id="add_client_form_notify_account" <?php echo (isset($add_client_data_notify_account) && $add_client_data_notify_account == 1) ? 'checked="checked"' : ''; ?>> <?php _e('Notify user of account creation by e-mail','cftp_admin'); ?>
+						<input type="checkbox" name="add_client_form_notify_account" id="add_client_form_notify_account" <?php echo (isset($add_client_data_notify_account) && $add_client_data_notify_account == 1) ? 'checked="checked"' : ''; ?>> <?php _e('Send welcome email','cftp_admin'); ?>
 					</label>
 				</div>
 			</div>
@@ -326,14 +326,8 @@ switch ($clients_form_type) {
 
 	<?php
 		if ($info_box == true) {
-			if ( $clients_form_type == 'new_client_self' ) {
-				$msg = __('This account information will be e-mailed to the address supplied above','cftp_admin');
-				echo system_message('info',$msg);
-			}
-			else {
-				$msg = __('This account information will be e-mailed to the address supplied above by default unless de-selected','cftp_admin');
-				echo system_message('info',$msg);
-			}
+			$msg = __('This account information will be e-mailed to the address supplied above','cftp_admin');
+			echo system_message('info',$msg);
 		}
 	?>
 </form>

--- a/clients-form.php
+++ b/clients-form.php
@@ -326,8 +326,14 @@ switch ($clients_form_type) {
 
 	<?php
 		if ($info_box == true) {
-			$msg = __('This account information will be e-mailed to the address supplied above by default unless de-selected','cftp_admin');
-			echo system_message('info',$msg);
+			if ( $clients_form_type == 'new_client_self' ) {
+				$msg = __('This account information will be e-mailed to the address supplied above','cftp_admin');
+				echo system_message('info',$msg);
+			}
+			else {
+				$msg = __('This account information will be e-mailed to the address supplied above by default unless de-selected','cftp_admin');
+				echo system_message('info',$msg);
+			}
 		}
 	?>
 </form>

--- a/includes/classes/actions-clients.php
+++ b/includes/classes/actions-clients.php
@@ -54,7 +54,8 @@ class ClientActions
 		$this->address = $arguments['address'];
 		$this->phone = $arguments['phone'];
 		$this->contact = $arguments['contact'];
-		$this->notify = $arguments['notify'];
+		$this->notify_account = $arguments['notify_account'];
+		$this->notify_upload = $arguments['notify_upload'];
 		$this->max_file_size = ( !empty( $arguments['max_file_size'] ) ) ? $arguments['max_file_size'] : 0;
 		$this->type = $arguments['type'];
 		$this->recaptcha = ( isset( $arguments['recaptcha'] ) ) ? $arguments['recaptcha'] : '';
@@ -141,7 +142,8 @@ class ClientActions
 		$this->address			= encode_html($arguments['address']);
 		$this->phone			= encode_html($arguments['phone']);
 		$this->contact			= encode_html($arguments['contact']);
-		$this->notify			= ( $arguments['notify'] == '1' ) ? 1 : 0;
+		$this->notify_upload    	= ( $arguments['notify_upload'] == '1' ) ? 1 : 0;
+		$this->notify_account   	= ( $arguments['notify_account'] == '1' ) ? 1 : 0;
 		$this->max_file_size	= ( !empty( $arguments['max_file_size'] ) ) ? $arguments['max_file_size'] : 0;
 		$this->request			= ( !empty( $arguments['account_requested'] ) ) ? $arguments['account_requested'] : 0;
 		$this->active			= ( $arguments['active'] );
@@ -164,7 +166,7 @@ class ClientActions
 			$this->sql_query->bindParam(':address', $this->address);
 			$this->sql_query->bindParam(':phone', $this->phone);
 			$this->sql_query->bindParam(':email', $this->email);
-			$this->sql_query->bindParam(':notify', $this->notify, PDO::PARAM_INT);
+			$this->sql_query->bindParam(':notify', $this->notify_upload, PDO::PARAM_INT);
 			$this->sql_query->bindParam(':contact', $this->contact);
 			$this->sql_query->bindParam(':admin', $this->this_admin);
 			$this->sql_query->bindParam(':active', $this->active, PDO::PARAM_INT);
@@ -185,13 +187,18 @@ class ClientActions
 												'username'	=> $this->username,
 												'password'	=> $this->password
 											);
-				$this->notify_send = $this->notify_client->psend_send_email($this->email_arguments);
+				if ($this->notify_account == 1) {
+					$this->notify_send = $this->notify_client->psend_send_email($this->email_arguments);
 
-				if ($this->notify_send == 1){
-					$this->state['email'] = 1;
+					if ($this->notify_send == 1){
+						$this->state['email'] = 1;
+					}
+					else {
+						$this->state['email'] = 0;
+					}
 				}
 				else {
-					$this->state['email'] = 0;
+					$this->state['email'] = 2;
 				}
 			}
 			else {
@@ -223,7 +230,7 @@ class ClientActions
 		$this->address			= encode_html($arguments['address']);
 		$this->phone			= encode_html($arguments['phone']);
 		$this->contact			= encode_html($arguments['contact']);
-		$this->notify			= ( $arguments['notify'] == '1' ) ? 1 : 0;
+		$this->notify_upload		= ( $arguments['notify_upload'] == '1' ) ? 1 : 0;
 		$this->active			= ( $arguments['active'] == '1' ) ? 1 : 0;
 		$this->max_file_size	= ( !empty( $arguments['max_file_size'] ) ) ? $arguments['max_file_size'] : 0;
 		$this->enc_password		= $hasher->HashPassword($arguments['password']);
@@ -258,7 +265,7 @@ class ClientActions
 			$this->sql_query->bindParam(':phone', $this->phone);
 			$this->sql_query->bindParam(':email', $this->email);
 			$this->sql_query->bindParam(':contact', $this->contact);
-			$this->sql_query->bindParam(':notify', $this->notify, PDO::PARAM_INT);
+			$this->sql_query->bindParam(':notify', $this->notify_upload, PDO::PARAM_INT);
 			$this->sql_query->bindParam(':active', $this->active, PDO::PARAM_INT);
 			$this->sql_query->bindParam(':max_file_size', $this->max_file_size, PDO::PARAM_INT);
 			$this->sql_query->bindParam(':id', $this->id, PDO::PARAM_INT);

--- a/includes/classes/actions-users.php
+++ b/includes/classes/actions-users.php
@@ -33,6 +33,7 @@ class UserActions
 		$this->password = $arguments['password'];
 		//$this->password_repeat = $arguments['password_repeat'];
 		$this->role = $arguments['role'];
+		$this->notify_account = $arguments['notify_account'];
 		$this->max_file_size = ( !empty( $arguments['max_file_size'] ) ) ? $arguments['max_file_size'] : 0;
 		$this->type = $arguments['type'];
 
@@ -111,6 +112,7 @@ class UserActions
 		$this->email			= encode_html($arguments['email']);
 		$this->role				= $arguments['role'];
 		$this->active			= $arguments['active'];
+		$this->notify_account           = ( $arguments['notify_account'] == '1' ) ? 1 : 0;
 		$this->max_file_size	= ( !empty( $arguments['max_file_size'] ) ) ? $arguments['max_file_size'] : 0;
 		//$this->enc_password = md5(mysql_real_escape_string($this->password));
 		$this->enc_password	= $hasher->HashPassword($this->password);
@@ -144,13 +146,18 @@ class UserActions
 												'username'	=> $this->username,
 												'password'	=> $this->password
 											);
-				$this->notify_send = $this->notify_user->psend_send_email($this->email_arguments);
+				if ($this->notify_account == 1) {
+					$this->notify_send = $this->notify_user->psend_send_email($this->email_arguments);
 
-				if ($this->notify_send == 1){
-					$this->state['email'] = 1;
+					if ($this->notify_send == 1){
+						$this->state['email'] = 1;
+					}
+					else {
+						$this->state['email'] = 0;
+					}
 				}
 				else {
-					$this->state['email'] = 0;
+					$this->state['email'] = 2;
 				}
 			}
 			else {

--- a/register.php
+++ b/register.php
@@ -35,7 +35,7 @@ include('header-unlogged.php');
 		$add_client_data_addr = (isset($_POST["add_client_form_address"])) ? encode_html($_POST["add_client_form_address"]) : '';
 		$add_client_data_phone = (isset($_POST["add_client_form_phone"])) ? encode_html($_POST["add_client_form_phone"]) : '';
 		$add_client_data_intcont = (isset($_POST["add_client_form_intcont"])) ? encode_html($_POST["add_client_form_intcont"]) : '';
-		$add_client_data_notity = (isset($_POST["add_client_form_notify"])) ? 1 : 0;
+		$add_client_data_notify_upload = (isset($_POST["add_client_form_notify_upload"])) ? 1 : 0;
 		$add_client_data_group = (isset($_POST["add_client_group_request"])) ? $_POST["add_client_group_request"] : '';
 	
 		/** Arguments used on validation and client creation. */
@@ -49,7 +49,7 @@ include('header-unlogged.php');
 								'address'	=> $add_client_data_addr,
 								'phone'		=> $add_client_data_phone,
 								'contact'	=> $add_client_data_intcont,
-								'notify'	=> $add_client_data_notity,
+								'notify_upload'	=> $add_client_data_notity_upload,
 								'group'		=> $add_client_data_group,
 								'type'		=> 'new_client',
 							);

--- a/users-add.php
+++ b/users-add.php
@@ -24,6 +24,7 @@ include('header.php');
  * the form
  */
 $add_user_data_active = 1;
+$add_user_data_notify_account = 1;
 
 if ($_POST) {
 	$new_user = new UserActions();
@@ -38,6 +39,7 @@ if ($_POST) {
 	$add_user_data_user = encode_html($_POST['add_user_form_user']);
 	$add_user_data_maxfilesize = (isset($_POST["add_user_form_maxfilesize"])) ? encode_html($_POST["add_user_form_maxfilesize"]) : '';
 	$add_user_data_active = (isset($_POST["add_user_form_active"])) ? 1 : 0;
+	$add_user_data_notify_account = (isset($_POST["add_user_form_notify_account"])) ? 1 : 0;
 
 	/** Arguments used on validation and user creation. */
 	$new_arguments = array(
@@ -50,6 +52,7 @@ if ($_POST) {
 							'role' => $add_user_data_level,
 							'active' => $add_user_data_active,
 							'max_file_size'	=> $add_user_data_maxfilesize,
+							'notify_account' => $add_user_data_notify_account,
 							'type' => 'new_user'
 						);
 
@@ -104,8 +107,12 @@ if ($_POST) {
 					 * Show the ok or error message for the email notification.
 					 */
 					switch ($new_response['email']) {
+						case 2:
+							$msg = __('A welcome message was not sent to the new user.','cftp_admin');
+							echo system_message('ok',$msg);
+						break;
 						case 1:
-							$msg = __('An e-mail notification with login information was sent to the new user.','cftp_admin');
+							$msg = __('A welcome message with login information was sent to the new user.','cftp_admin');
 							echo system_message('ok',$msg);
 						break;
 						case 0:

--- a/users-form.php
+++ b/users-form.php
@@ -150,6 +150,22 @@ switch ($user_form_type) {
 					</label>
 				</div>
 			</div>
+
+			<?php
+				if ( $user_form_type == 'new_user' ) {
+			?>
+
+					<div class="form-group">
+						<div class="col-sm-8 col-sm-offset-4">
+							<label for="add_user_form_notify_account">
+								<input type="checkbox" name="add_user_form_notify_account" id="add_user_form_notify_account" <?php echo (isset($add_user_data_notify_account) && $add_user_data_notify_account == 1) ? 'checked="checked"' : ''; ?> /> <?php _e('Send welcome email','cftp_admin'); ?>
+							</label>
+						</div>
+					</div>
+			<?php
+				}
+			?>
+
 		<?php
 			}
 		?>


### PR DESCRIPTION
This is a bit of an edge use case but this change introduces an option on the create client screen where email notification to the new user of the account creation can be disabled.  Notification is left enabled by default (as it is now) and is not sticky as I'm assuming most will want to only use this on an exceptional basis